### PR TITLE
Fix - set min values to 0 for grafana widgets

### DIFF
--- a/grafana/provisioning/dashboards/dashboard.json
+++ b/grafana/provisioning/dashboards/dashboard.json
@@ -99,7 +99,7 @@
               "id": "byValue",
               "options": {
                 "op": "lt",
-                "reducer": "lastNotNull",
+                "reducer": "mean",
                 "value": 0
               }
             },
@@ -299,6 +299,7 @@
             }
           },
           "mappings": [],
+          "min": 0,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -314,7 +315,28 @@
           },
           "unit": "s"
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byValue",
+              "options": {
+                "op": "lt",
+                "reducer": "mean",
+                "value": 0
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,


### PR DESCRIPTION
Set min value for HTTP and ping RTT widgets to 0. Failed hosts have a set value of -1, but this will not adjust the y-axis. This allows the failed hosts to be hidden until successful. 